### PR TITLE
Ignore import files for icon

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,3 +12,5 @@
 /CONTRIBUTING.md export-ignore
 /icon.png export-ignore
 /icon.svg export-ignore
+/icon.png.import export-ignore
+/icon.svg.import export-ignore


### PR DESCRIPTION
We're ignoring icon.png, so also ignore the autogenerated import file. Same for svg.

I downloaded a zip and it contained the icon.png.import, but I think the goal of these attributes is to avoid that?